### PR TITLE
release: Bump version to v1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,18 @@
+## [1.0.1] - 2026-03-06
+
+### Added
+- Route middleware for role and permission checks (`RequireRole`, `RequirePermission`)
+- Artisan commands for role and permission management (`CreateRoleCommand`, `CreatePermissionCommand`, `AssignRoleCommand`)
+- Base seeder for roles and permissions (`RolesAndPermissionsSeeder`)
+- Comprehensive ability tests
+- Tests for middleware, commands, and seeder
+
+### Fixed
+- Add missing database migrations (`role_permissions`, `role_assignments`, `abilities` tables)
+
+### Changed
+- Added `cviebrock/eloquent-sluggable` dependency
+- Updated package name
+
 ## [1.0.0] - 2025-10-02
 - Initial release

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "whilesmart/eloquent-roles",
   "description": "Flexible roles and permissions package for Laravel applications",
-  "package-version": "1.0.0",
+  "package-version": "1.0.1",
   "keywords": [
     "laravel",
     "roles",


### PR DESCRIPTION
## Summary
- Bump `package-version` in `composer.json` from `1.0.0` to `1.0.1`
- Add `## [1.0.1]` changelog entry covering all new features, fixes, and changes since v1.0.0

## Changelog
### Added
- Route middleware for role and permission checks
- Artisan commands for role and permission management
- Base seeder for roles and permissions
- Comprehensive ability tests
- Tests for middleware, commands, and seeder

### Fixed
- Add missing database migrations

### Changed
- Added `cviebrock/eloquent-sluggable` dependency
- Updated package name