### PR TITLE
fix: Widen eloquent-sluggable version constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
   ],
   "require": {
     "php": "^8.2",
-    "cviebrock/eloquent-sluggable": "^12.0",
+    "cviebrock/eloquent-sluggable": "^11.0|^12.0",
     "laravel/framework": "^11.0|^12.0"
   },
   "require-dev": {


### PR DESCRIPTION
## Summary
- Widen `cviebrock/eloquent-sluggable` constraint from `^12.0` to `^11.0|^12.0`
- Matches the approach already used for `laravel/framework`